### PR TITLE
Fixed typo in currencies.json

### DIFF
--- a/currencies.json
+++ b/currencies.json
@@ -61,7 +61,7 @@
     },
     {
         "code": "JPY",
-        "symbool": "¥"
+        "symbol": "¥"
     },
     {
         "code": "KRW",


### PR DESCRIPTION
There was a type in the currency.json file which would cause the JPY symbol to return undefined when mapped.