### PR TITLE
Require API key

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -35,6 +35,7 @@
         "strict": "off",
         "import/newline-after-import": "off",
         "no-param-reassign": "off",
-        "no-useless-return": "off"
+        "no-useless-return": "off",
+        "max-len": "off"
     }
 }

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ $ npm install btc-value
 ```js
 const btcValue = require('btc-value');
 
+// Set the API key
+btcValue.setApiKey('example-API-key');
+
 // Print the current value of Bitcoin in USD
 btcValue().then(value => {
     console.log('$' + value);
@@ -56,7 +59,7 @@ console.log(btcValue.currencies);
 ```
 
 ## API
-The Bitcoin value is from [Cryptocurrency Market Capitalizations](https://coinmarketcap.com/). See API [here](https://coinmarketcap.com/api/).
+The Bitcoin value is from [Cryptocurrency Market Capitalizations](https://coinmarketcap.com/). See API [here](https://coinmarketcap.com/api/). To use the module for retrieve Bitcoin values, it is required to obtain and use an API key. This can be done [here](https://coinmarketcap.com/api/). Before using the functions for retrieving the Bitcoin value, one must then call `btcValue.setApiKey(<KEY_HERE>)` with your key.
 ### btcValue([options])
 Returns the current Bitcoin value in USD ($) as an `integer`.
 
@@ -79,6 +82,12 @@ Type: `string`<br>
 Default: `USD`
 
 Returns the current Bitcoin value in a different currency than `USD`. All valid currency codes are stored in the [currencies.json](currencies.json) file.
+
+### btcValue.setApiKey(apiKey)
+Sets the API key for the [Cryptocurrency Market Capitalizations API](https://coinmarketcap.com/api/) used in the requests. This is required to call the other functions.
+
+#### apiKey
+Type: `string`<br>
 
 ### btcValue.getPercentageChangeLastHour()
 Returns the percentage change of BTC the last hour.

--- a/index.js
+++ b/index.js
@@ -2,9 +2,17 @@
 
 const https = require('https');
 const currencies = require('./currencies.json');
-const apiURL = 'https://api.coinmarketcap.com/v1/ticker/bitcoin/';
+const baseUrl = 'https://pro-api.coinmarketcap.com/v1/cryptocurrency/quotes/latest?symbol=BTC';
+let apiKey = '';
 
-function sendHttpRequest(url) {
+function sendHttpRequest(urlParameters = '') {
+    // Check if the api key is provided
+    if (!apiKey) {
+        throw new Error('`apiKey` needs to be set. Call `.setApiKey()` with your API key before calling other functions.');
+    }
+
+    const url = `${baseUrl}${urlParameters}&CMC_PRO_API_KEY=${apiKey}`;
+
     return new Promise((resolve, reject) => {
         https.get(url, response => {
             if (response.statusCode < 200 || response.statusCode > 299) {
@@ -21,7 +29,14 @@ function sendHttpRequest(url) {
 
             response.on('end', () => {
                 try {
-                    resolve(JSON.parse(data)[0]);
+                    const jsonResponse = JSON.parse(data);
+
+                    // Check if there are errors in the API response
+                    if (jsonResponse.status && jsonResponse.status.error_code !== 0) {
+                        reject(new Error(`Error occurred while retrieving Bitcoin value: ${jsonResponse.status.error_message}`));
+                    }
+
+                    resolve(jsonResponse.data.BTC);
                 } catch (error) {
                     // If not able to parse JSON or get the first parsed value
                     reject(new Error('Failed to retrieve Bitcoin value'));
@@ -35,8 +50,17 @@ function sendHttpRequest(url) {
     });
 }
 
+function setApiKey(key) {
+    // Check if the API key is provided
+    if (!key) {
+        throw new Error('You need to provide an API key.');
+    }
+
+    apiKey = key;
+}
+
 function convertToTwoDecimals(number) {
-    // Check if the number is not a int => convert to 2 decimals
+    // Check if the number is not an integer. If it is not, convert it to two decimals.
     if (number % 1 !== 0) {
         return parseFloat(number.toFixed(2));
     }
@@ -47,15 +71,8 @@ function convertToTwoDecimals(number) {
 function parseOptions(currencyValue, options) {
     const {isDecimal, quantity} = options;
 
-    if (typeof isDecimal !== 'boolean') {
-        throw new TypeError('`isDecimal` should be of type `boolean`');
-    }
-
+    // Set the new currency value if quantity is provided
     if (quantity) {
-        if (typeof quantity !== 'number') {
-            throw new TypeError('`quantity` should be of type `number`');
-        }
-
         currencyValue *= quantity;
     }
 
@@ -67,13 +84,9 @@ function parseOptions(currencyValue, options) {
     return convertToTwoDecimals(currencyValue);
 }
 
-// input1 can both be boolean (isDecimal) and number (quantity), but not the same type
-// input2 can be boolean (isDecimal) if input1 is number (quantity)
-// TODO: new text here
-
 function getValue(options) {
     return new Promise((resolve, reject) => {
-        let url = apiURL;
+        let urlParameters = '';
 
         // Set default value of `currencyCode` and `isDecimal`
         options = {
@@ -82,11 +95,23 @@ function getValue(options) {
             ...options
         };
 
-        const {currencyCode} = options;
+        let {currencyCode} = options;
+        const {isDecimal, quantity} = options;
 
         // Check that the type of `currencyCode` is `string`
         if (typeof currencyCode !== 'string') {
             throw new TypeError('`currencyCode` should be of type `string`');
+        }
+
+        // Ensure the currency code is uppercase
+        currencyCode = currencyCode.toUpperCase();
+
+        if (typeof isDecimal !== 'boolean') {
+            throw new TypeError('`isDecimal` should be of type `boolean`');
+        }
+
+        if (quantity && typeof quantity !== 'number') {
+            throw new TypeError('`quantity` should be of type `number`');
         }
 
         // Check if the current currency code mathches any valid ones
@@ -104,12 +129,12 @@ function getValue(options) {
         }
 
         if (currencyCode !== 'USD') {
-            url += `?convert=${currencyCode}`;
+            urlParameters += `&convert=${currencyCode}`;
         }
 
-        sendHttpRequest(url).then(response => {
+        sendHttpRequest(urlParameters).then(response => {
             // Set the `currencyValue` to the `USD` value by default
-            let currencyValue = (currencyCode === 'USD') ? response.price_usd : response[`price_${currencyCode.toLowerCase()}`];
+            let currencyValue = (currencyCode === 'USD') ? response.quote.USD.price : response.quote[currencyCode].price;
 
             if (!currencyValue) {
                 reject(new Error('Failed to retrieve Bitcoin value'));
@@ -126,24 +151,21 @@ function getValue(options) {
 
 function getPercentageChangeLastTime(type) {
     return new Promise((resolve, reject) => {
-        sendHttpRequest(apiURL).then(response => {
-            try {
-                if (!response[`percent_change_${type}`]) {
-                    throw new Error('Failed to retrieve percentage change');
-                }
-
-                const percentageChange = parseFloat(response[`percent_change_${type}`]);
-                resolve(percentageChange);
-                return;
-            } catch (error) {
-                reject(new Error('Failed to retrieve percentage change'));
-                return;
+        sendHttpRequest().then(response => {
+            if (!response.quote || !response.quote.USD || (response.quote && !response.quote.USD[`percent_change_${type}`])) {
+                throw new Error('Failed to retrieve percentage change');
             }
-        });
+
+            const percentageChange = parseFloat(response.quote.USD[`percent_change_${type}`]);
+            resolve(percentageChange);
+            return;
+        }).catch(error => reject(error));
     });
 }
 
 module.exports = options => getValue(options);
+
+module.exports.setApiKey = key => setApiKey(key);
 
 module.exports.getPercentageChangeLastHour = () => getPercentageChangeLastTime('1h');
 

--- a/index.js
+++ b/index.js
@@ -3,15 +3,15 @@
 const https = require('https');
 const currencies = require('./currencies.json');
 const baseUrl = 'https://pro-api.coinmarketcap.com/v1/cryptocurrency/quotes/latest?symbol=BTC';
-let apiKey = '';
+let cmcApiKey = '';
 
 function sendHttpRequest(urlParameters = '') {
     // Check if the api key is provided
-    if (!apiKey) {
+    if (!cmcApiKey) {
         throw new Error('`apiKey` needs to be set. Call `.setApiKey()` with your API key before calling other functions.');
     }
 
-    const url = `${baseUrl}${urlParameters}&CMC_PRO_API_KEY=${apiKey}`;
+    const url = `${baseUrl}${urlParameters}&CMC_PRO_API_KEY=${cmcApiKey}`;
 
     return new Promise((resolve, reject) => {
         https.get(url, response => {
@@ -50,13 +50,18 @@ function sendHttpRequest(urlParameters = '') {
     });
 }
 
-function setApiKey(key) {
+function setApiKey(apiKey) {
     // Check if the API key is provided
-    if (!key) {
+    if (!apiKey) {
         throw new Error('You need to provide an API key.');
     }
 
-    apiKey = key;
+    // Check that the type of `apiKey` is `string`
+    if (typeof apiKey !== 'string') {
+        throw new TypeError('`apiKey` should be of type `string`');
+    }
+
+    cmcApiKey = apiKey;
 }
 
 function convertToTwoDecimals(number) {

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ function sendHttpRequest(urlParameters = '') {
 
     return new Promise((resolve, reject) => {
         https.get(url, response => {
-            if (response.statusCode < 200 || response.statusCode > 299) {
+            if (response.statusCode < 200 || (response.statusCode > 299 && response.statusCode !== 401)) {
                 reject(new Error(`Failed to load url: ${response.statusCode}`));
                 return;
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -764,12 +764,6 @@
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "dev": true
     },
-    "assertion-error": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-      "dev": true
-    },
     "astral-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
@@ -1276,20 +1270,6 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
-    "chai": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
-      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
-      "dev": true,
-      "requires": {
-        "assertion-error": "^1.1.0",
-        "check-error": "^1.0.2",
-        "deep-eql": "^3.0.1",
-        "get-func-name": "^2.0.0",
-        "pathval": "^1.1.0",
-        "type-detect": "^4.0.5"
-      }
-    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -1316,12 +1296,6 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-      "dev": true
-    },
-    "check-error": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
     },
     "chokidar": {
@@ -1788,15 +1762,6 @@
       "dev": true,
       "requires": {
         "mimic-response": "^1.0.0"
-      }
-    },
-    "deep-eql": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
-      "dev": true,
-      "requires": {
-        "type-detect": "^4.0.0"
       }
     },
     "deep-equal": {
@@ -2803,12 +2768,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true
-    },
-    "get-func-name": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
     "get-port": {
@@ -4001,20 +3960,15 @@
       "dev": true
     },
     "nock": {
-      "version": "10.0.6",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-10.0.6.tgz",
-      "integrity": "sha512-b47OWj1qf/LqSQYnmokNWM8D88KvUl2y7jT0567NB3ZBAZFz2bWp2PC81Xn7u8F2/vJxzkzNZybnemeFa7AZ2w==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-12.0.2.tgz",
+      "integrity": "sha512-pTckyfP8QHvwXP/oX+zQuSIL3S/mWTd84ba4pOGZlS/FgRZyljv4C3ZyOjgMilvkydSaERML/aJEF13EBUuDTQ==",
       "dev": true,
       "requires": {
-        "chai": "^4.1.2",
         "debug": "^4.1.0",
-        "deep-equal": "^1.0.0",
         "json-stringify-safe": "^5.0.1",
-        "lodash": "^4.17.5",
-        "mkdirp": "^0.5.0",
-        "propagate": "^1.0.0",
-        "qs": "^6.5.1",
-        "semver": "^5.5.0"
+        "lodash": "^4.17.13",
+        "propagate": "^2.0.0"
       }
     },
     "normalize-package-data": {
@@ -4505,12 +4459,6 @@
         }
       }
     },
-    "pathval": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
-      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
-      "dev": true
-    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -4691,9 +4639,9 @@
       "dev": true
     },
     "propagate": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/propagate/-/propagate-1.0.0.tgz",
-      "integrity": "sha1-AMLa7t2iDofjeCs0Stuhzd1q1wk=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
       "dev": true
     },
     "pseudomap": {
@@ -5576,12 +5524,6 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
-    },
-    "type-detect": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true
     },
     "type-fest": {
       "version": "0.5.2",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "eslint-config-airbnb-base": "^14.0.0",
     "eslint-plugin-ava": "^8.0.0",
     "eslint-plugin-import": "^2.18.2",
-    "nock": "^10.0.6",
+    "nock": "^12.0.2",
     "nyc": "^14.1.1"
   }
 }

--- a/test.js
+++ b/test.js
@@ -2,8 +2,19 @@ import test from 'ava';
 import nock from 'nock';
 import btcValue from '.';
 
-test.before(() => {
-    // Set an example API key for all tests
+test.before(async t => {
+    const expectedResult = new Error('`apiKey` needs to be set. Call `.setApiKey()` with your API key before calling other functions.');
+
+    // Check that the function can not be called without an API key
+    // This will throw an error
+    try {
+        await btcValue();
+        t.fail();
+    } catch (error) {
+        t.deepEqual(error, expectedResult);
+    }
+
+    // Set an example API key for all remaining tests
     btcValue.setApiKey('example-CMC-PRO-API-key');
 });
 
@@ -51,11 +62,15 @@ test('throws error if no API key is provided to `.setApiKey()`', t => {
     }
 });
 
-// TODO: test this
-// test('throws error if no API keys is not set', async t => {
-//     // Reset the API key for this function
-//     // This happens if `.setApiKey()` is not called
-// });
+test('throws TypeError when `apiKey` is not a string', t => {
+    const expectedResult = new TypeError('`apiKey` should be of type `string`');
+
+    try {
+        btcValue.setApiKey(1337);
+    } catch (error) {
+        t.deepEqual(error, expectedResult);
+    }
+});
 
 test('returned value is a number', async t => {
     try {

--- a/test.js
+++ b/test.js
@@ -2,21 +2,62 @@ import test from 'ava';
 import nock from 'nock';
 import btcValue from '.';
 
+test.before(() => {
+    // Set an example API key for all tests
+    btcValue.setApiKey('example-CMC-PRO-API-key');
+});
+
 test.after(() => {
     // Clean all nocks
     nock.cleanAll();
 });
 
-test('value return something', async t => {
+test.beforeEach(() => {
+    nock('https://pro-api.coinmarketcap.com')
+        .get(/v1\/cryptocurrency\/quotes\/latest/)
+        .reply(200, {
+            status: {
+                error_code: 0,
+                error_message: null
+            },
+            data: {
+                BTC: {
+                    quote: {
+                        USD: {
+                            price: 8983.34736401,
+                            percent_change_1h: -1.67074,
+                            percent_change_24h: -1.0296,
+                            percent_change_7d: 3.72573
+                        },
+                        NOK: {
+                            price: 83110.91835295832,
+                            percent_change_1h: -1.73148,
+                            percent_change_24h: -1.05610461,
+                            percent_change_7d: 2.12793914
+                        }
+                    }
+                }
+            }
+        });
+});
+
+test('throws error if no API key is provided to `.setApiKey()`', t => {
+    const expectedResult = new Error('You need to provide an API key.');
+
     try {
-        await btcValue();
-        t.pass();
+        btcValue.setApiKey('');
     } catch (error) {
-        t.fail();
+        t.deepEqual(error, expectedResult);
     }
 });
 
-test('returned value is a number #1', async t => {
+// TODO: test this
+// test('throws error if no API keys is not set', async t => {
+//     // Reset the API key for this function
+//     // This happens if `.setApiKey()` is not called
+// });
+
+test('returned value is a number', async t => {
     try {
         const value = await btcValue();
         t.is(typeof value, 'number');
@@ -57,20 +98,6 @@ test('percentage last week return a number', async t => {
         t.is(typeof value, 'number');
 
         if (Number.isNaN(value)) {
-            t.fail();
-        }
-    } catch (error) {
-        t.fail();
-    }
-});
-
-test('returned value is non-negative number', async t => {
-    try {
-        const value = await btcValue();
-
-        if (value >= 0) {
-            t.pass();
-        } else {
             t.fail();
         }
     } catch (error) {
@@ -149,6 +176,7 @@ test('return integer when `isDecimal` is not in options', async t => {
         t.is(typeof value, 'number');
         t.is(value % 1, 0);
     } catch (error) {
+        t.is(error, '');
         t.fail();
     }
 });
@@ -198,10 +226,12 @@ test('return Error when `currencyCode` is not a valid one', async t => {
 });
 
 test('server return invalid data response', async t => {
-    const expectedResult = new TypeError('Cannot read property \'price_usd\' of undefined');
+    const expectedResult = new Error('Failed to retrieve Bitcoin value');
 
-    nock('https://api.coinmarketcap.com')
-        .get('/v1/ticker/bitcoin/')
+    nock.cleanAll();
+
+    nock('https://pro-api.coinmarketcap.com')
+        .get(/v1\/cryptocurrency\/quotes\/latest/)
         .reply(200, {
             invalid_response: 'here'
         });
@@ -217,8 +247,10 @@ test('server return invalid data response', async t => {
 test('server return non-JSON response', async t => {
     const expectedResult = new Error('Failed to retrieve Bitcoin value');
 
-    nock('https://api.coinmarketcap.com')
-        .get('/v1/ticker/bitcoin/')
+    nock.cleanAll();
+
+    nock('https://pro-api.coinmarketcap.com')
+        .get(/v1\/cryptocurrency\/quotes\/latest/)
         .reply(200, 'no_json here');
 
     try {
@@ -232,8 +264,10 @@ test('server return non-JSON response', async t => {
 test('server return invalid HTTP status code (123)', async t => {
     const expectedResult = new Error('Failed to load url: 123');
 
-    nock('https://api.coinmarketcap.com')
-        .get('/v1/ticker/bitcoin/')
+    nock.cleanAll();
+
+    nock('https://pro-api.coinmarketcap.com')
+        .get(/v1\/cryptocurrency\/quotes\/latest/)
         .reply(123, {
             invalid_response: 'here'
         });
@@ -249,8 +283,10 @@ test('server return invalid HTTP status code (123)', async t => {
 test('server return invalid HTTP status code (1337)', async t => {
     const expectedResult = new Error('Failed to load url: 1337');
 
-    nock('https://api.coinmarketcap.com')
-        .get('/v1/ticker/bitcoin/')
+    nock.cleanAll();
+
+    nock('https://pro-api.coinmarketcap.com')
+        .get(/v1\/cryptocurrency\/quotes\/latest/)
         .reply(1337, {
             invalid_response: 'here'
         });
@@ -270,8 +306,10 @@ test('server return error code', async t => {
         syscall: 'connect'
     };
 
-    nock('https://api.coinmarketcap.com')
-        .get('/v1/ticker/bitcoin/')
+    nock.cleanAll();
+
+    nock('https://pro-api.coinmarketcap.com')
+        .get(/v1\/cryptocurrency\/quotes\/latest/)
         .replyWithError({
             errno: 'ECONNREFUSED',
             code: 'ECONNREFUSED',
@@ -289,8 +327,10 @@ test('server return error code', async t => {
 test('server return missing data (missing `price_usd`)', async t => {
     const expectedResult = new Error('Failed to retrieve Bitcoin value');
 
-    nock('https://api.coinmarketcap.com')
-        .get('/v1/ticker/bitcoin/')
+    nock.cleanAll();
+
+    nock('https://pro-api.coinmarketcap.com')
+        .get(/v1\/cryptocurrency\/quotes\/latest/)
         .reply(200, [
             {
                 missing_data: 'here'
@@ -308,16 +348,70 @@ test('server return missing data (missing `price_usd`)', async t => {
 test('server return missing data (missing percent change)', async t => {
     const expectedResult = new Error('Failed to retrieve percentage change');
 
-    nock('https://api.coinmarketcap.com')
-        .get('/v1/ticker/bitcoin/')
-        .reply(200, [
+    nock.cleanAll();
+
+    nock('https://pro-api.coinmarketcap.com')
+        .get(/v1\/cryptocurrency\/quotes\/latest/)
+        .reply(200, {
+            data:
             {
-                missing_data: 'here'
+                BTC: {
+                    missing_data: 'here'
+                }
             }
-        ]);
+        });
 
     try {
         await btcValue.getPercentageChangeLastWeek();
+        t.fail();
+    } catch (error) {
+        t.deepEqual(error, expectedResult);
+    }
+});
+
+test('throws error if API key is invalid', async t => {
+    const expectedResult = new Error('Error occurred while retrieving Bitcoin value: This API Key is invalid.');
+
+    nock.cleanAll();
+
+    nock('https://pro-api.coinmarketcap.com')
+        .get(/v1\/cryptocurrency\/quotes\/latest/)
+        .reply(200, {
+            status: {
+                error_code: 1001,
+                error_message: 'This API Key is invalid.'
+            }
+        });
+
+    try {
+        await btcValue();
+        t.fail();
+    } catch (error) {
+        t.deepEqual(error, expectedResult);
+    }
+});
+
+test('server return missing data (missing currency value)', async t => {
+    const expectedResult = new Error('Failed to retrieve Bitcoin value');
+
+    nock.cleanAll();
+
+    nock('https://pro-api.coinmarketcap.com')
+        .get(/v1\/cryptocurrency\/quotes\/latest/)
+        .reply(200, {
+            data: {
+                BTC: {
+                    quote: {
+                        USD: {
+                            something_else: 'here'
+                        }
+                    }
+                }
+            }
+        });
+
+    try {
+        await btcValue();
         t.fail();
     } catch (error) {
         t.deepEqual(error, expectedResult);


### PR DESCRIPTION
The new version of the [Cryptocurrency Market Capitalizations API](https://coinmarketcap.com/api/) requires the user to provide an API key. This is handled in this PR with a new function `btcValue.setApiKey(<KEY_HERE>)`, that needs to be called before using the rest of the functions that calls the API.

This fixes #17.